### PR TITLE
Scrollbar bug fix

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,5 @@
 html {
+    overflow: hidden;
     background-color: #7f5a83;
     background-image: linear-gradient(315deg, #7f5a83 0%, #0d324d 74%);    
     background-size: cover;


### PR DESCRIPTION
Removed the unrequired scrollbar on the right edge of the page which was not covered by the gradient and looked out of place.

Some other CSS suggestions (let me know if I should create a pull request for these):
1. Purge the unused parts of bulma.min.css (reduces 191 KB to 6 KB) and merge with style.css
2. Restore the previous gradient (the one in the GIF), it looks a lot better
3. Remove the shadow around the message (class 'message')
4. Remove the \<br\> between username and message